### PR TITLE
Add encode method call to Soundex test

### DIFF
--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -7,5 +7,6 @@ public class SoundexEncodingTest
     public void RetainsSoleLetterOfOneLetterWord()
     {
         var soundex = new Soundex();
+        var encoded = soundex.Encode("A");
     }
 }


### PR DESCRIPTION
Before:

	•	The Soundex class existed, but the test did not include any method interaction.
	•	The test lacked a call to any method that would process the input.

After:

	•	Added a call to the Encode method within the RetainsSoleLetterOfOneLetterWord test.
	•	The test attempts to encode the letter "A", preparing the ground for implementing the Encode method.
	•	The test will currently fail due to the absence of the Encode method, guiding the next step in the TDD cycle.