### PR TITLE
Implement Encode method in Soundex class returning an empty string

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -2,4 +2,8 @@
 
 public class Soundex
 {
+    public string Encode(string word)
+    {
+        return string.Empty;
+    }
 }


### PR DESCRIPTION
Before:

	•	The Soundex class existed but lacked any implementation of the Encode method.
	•	The test was prepared to call the Encode method, but the method itself was missing.

After:

	•	Implemented the Encode method in the Soundex class.
	•	The Encode method currently returns an empty string, serving as the initial placeholder implementation.
	•	This basic implementation ensures the project compiles and the method signature is defined, though the functionality is not yet complete.