### PR TITLE
Update Encode method to return the input word

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -4,6 +4,6 @@ public class Soundex
 {
     public string Encode(string word)
     {
-        return "A";
+        return word;
     }
 }


### PR DESCRIPTION
Before:

	•	The Encode method in the Soundex class was hardcoded to return the string "A", limiting its ability to handle different inputs.
	•	This implementation only allowed passing tests where the input was "A".

After:

	•	Modified the Encode method to return the input word itself.
	•	This change allows the Encode method to pass tests for any single-letter word, as it now dynamically returns whatever input is provided.
	•	The method is now capable of handling different inputs, but it still lacks full Soundex encoding logic.