### PR TITLE
Add test to ensure Encode method pads with zeros to create a four-character code

### DIFF
--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -7,7 +7,7 @@ public class SoundexEncodingTest
     public void RetainsSoleLetterOfOneLetterWord()
     {
         var soundex = new Soundex();
-        var encoded = soundex.Encode("A");
-        Assert.Equal("A", encoded);
+       var encoded = soundex.Encode("I");
+        Assert.Equal("I000", encoded);
     }
 }


### PR DESCRIPTION
Before:

	•	The Encode method in the Soundex class returned the input word without any padding.
	•	There was no validation to ensure that the encoded output met the Soundex requirement of four characters.

After:

	•	Added a test to verify that the Encode method pads the result with zeros to ensure a four-character code.
	•	The test checks that calling Encode with the input "I" returns "I000".
	•	The Encode method currently only returns the input word without padding, so this test is expected to fail, guiding the next implementation step.