### PR TITLE
Implement zero-padding in Encode method and add test to validate four-character output

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -4,6 +4,6 @@ public class Soundex
 {
     public string Encode(string word)
     {
-        return word;
+        return word + "000";
     }
 }

--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -6,8 +6,22 @@ public class SoundexEncodingTest
     [Fact]
     public void RetainsSoleLetterOfOneLetterWord()
     {
+        // Arrange
         var soundex = new Soundex();
+        // Act
         var encoded = soundex.Encode("A");
-        Assert.Equal("A", encoded);
+        // Assert
+        Assert.Equal("A000", encoded);
+    }
+    
+    [Fact]
+    public void PadsWithZerosToEnsureThreeDigits()
+    {
+        // Arrange
+        var soundex = new Soundex();
+        // Act
+        var encoded = soundex.Encode("I");
+        // Assert
+        Assert.Equal("I000", encoded);
     }
 }


### PR DESCRIPTION
Before:

	•	The Encode method in the Soundex class returned the input word without adequate zero-padding to ensure four characters.
	•	There was no test specifically verifying that the Encode method pads single-letter inputs like "I" to meet the four-character Soundex code requirement.

After:

	•	Updated the Encode method to append "000" to the input word, ensuring that single-letter inputs are padded to create a four-character code.
	•	Added a test that verifies the Encode method pads the letter "I" with zeros, checking that the output is "I000".
	•	These changes ensure that the method consistently produces a four-character Soundex code, and the test confirms this behavior.