### PR TITLE
Refactor Encode method with helper function and consolidate test setup

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -4,6 +4,11 @@ public class Soundex
 {
     public string Encode(string word)
     {
+        return ZeroPad(word);
+    }
+    
+    private string ZeroPad(string word)
+    {
         return word + "000";
     }
 }

--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -3,13 +3,13 @@ using TDD_CSharp.Sources;
 namespace TDD_CSharp.Tests;
 public class SoundexEncodingTest
 {
+    private readonly Soundex _soundex = new();
+
     [Fact]
     public void RetainsSoleLetterOfOneLetterWord()
     {
-        // Arrange
-        var soundex = new Soundex();
         // Act
-        var encoded = soundex.Encode("A");
+        var encoded = _soundex.Encode("A");
         // Assert
         Assert.Equal("A000", encoded);
     }
@@ -17,10 +17,8 @@ public class SoundexEncodingTest
     [Fact]
     public void PadsWithZerosToEnsureThreeDigits()
     {
-        // Arrange
-        var soundex = new Soundex();
         // Act
-        var encoded = soundex.Encode("I");
+        var encoded = _soundex.Encode("I");
         // Assert
         Assert.Equal("I000", encoded);
     }


### PR DESCRIPTION
Before:

	•	The Encode method in the Soundex class directly handled zero-padding without using a dedicated helper function, leading to less modular code.
	•	Each test in the SoundexEncoding suite individually initialized a Soundex instance, resulting in repetitive code.

After:

	•	Refactored the Encode method to use a private helper function ZeroPad for adding zeros, improving code modularity and readability.
	•	Introduced a constructor in the SoundexEncoding test class to initialize a shared Soundex instance for all tests.
	•	Refactored existing tests (RetainsSoleLetterOfOneLetterWord and PadsWithZerosToEnsureThreeDigits) to utilize the shared instance, reducing redundancy.