### PR TITLE
Refactor test assertions to directly call Encode method without intermediate variables

### DIFF
--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -4,22 +4,16 @@ namespace TDD_CSharp.Tests;
 public class SoundexEncodingTest
 {
     private readonly Soundex _soundex = new();
-
+    
     [Fact]
     public void RetainsSoleLetterOfOneLetterWord()
     {
-        // Act
-        var encoded = _soundex.Encode("A");
-        // Assert
-        Assert.Equal("A000", encoded);
+        Assert.Equal("A000", _soundex.Encode("A"));
     }
-    
+
     [Fact]
     public void PadsWithZerosToEnsureThreeDigits()
     {
-        // Act
-        var encoded = _soundex.Encode("I");
-        // Assert
-        Assert.Equal("I000", encoded);
+        Assert.Equal("I000", _soundex.Encode("I"));
     }
 }


### PR DESCRIPTION

Before:

	•	The tests declared an intermediate variable to store the result of the Encode method before asserting its value.
	•	This added unnecessary verbosity to the test code.

After:

	•	Refactored the RetainsSoleLetterOfOneLetterWord and PadsWithZerosToEnsureThreeDigits tests to directly assert the output of the Encode method without storing it in a variable first.
	•	This change simplifies the test code, making it more concise and easier to read, while maintaining the same functionality.