### PR TITLE
Enhance ZeroPad method to dynamically calculate required zeros

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -14,6 +14,7 @@ public class Soundex
     
     private string ZeroPad(string word)
     {
-        return word + "000";
+        var zerosNeeded = 4 - word.Length;
+        return word + new string('0', zerosNeeded);
     }
 }


### PR DESCRIPTION
Before:

	•	The ZeroPad method in the Soundex class simply appended a fixed number of zeros, without considering the actual length of the input string.

After:

	•	Updated the ZeroPad method to calculate the number of zeros needed based on the length of the input string.
	•	The method now ensures that the resulting string is always exactly four characters long by dynamically adding the required number of zeros.
	•	This change improves the flexibility and correctness of the padding logic, allowing the method to handle varying input lengths more accurately.