### PR TITLE
Introduce MaxCodeLength constant and update ZeroPad method

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -2,6 +2,7 @@
 
 public class Soundex
 {
+    private const int MaxCodeLength = 4;
     public string Encode(string word)
     {
         return  ZeroPad(Head(word) + EncodedDigits(word));
@@ -20,7 +21,7 @@ public class Soundex
 
     private string ZeroPad(string word)
     {
-        var zerosNeeded = 4 - word.Length;
+        var zerosNeeded = MaxCodeLength - word.Length;
         return word + new string('0', zerosNeeded);
     }
 }


### PR DESCRIPTION
Before:

	•	The ZeroPad method hard-coded the length requirement, making the code less flexible and harder to maintain if the desired code length were to change.

After:

	•	Introduced a MaxCodeLength constant to define the desired length of the Soundex code.
	•	Updated the ZeroPad method to use MaxCodeLength for determining the number of zeros needed to pad the encoded string.
	• 	This change enhances the code’s flexibility and maintainability by eliminating “magic numbers,” making it easier to update if the length requirement changes in the future.