### PR TITLE
Refactor EncodedDigits method to use EncodedDigit helper function

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -10,9 +10,13 @@ public class Soundex
 
     private string EncodedDigits(string word)
     {
-        return word.Length > 1 ? "1" : string.Empty;
+        return word.Length > 1 ? EncodedDigit() : string.Empty;
     }
 
+    private string EncodedDigit()
+    {
+        return "1";
+    }
     private string Head(string word)
     {
         var encoded = word.Substring(0, 1);


### PR DESCRIPTION
Before:

	•	The EncodedDigits method directly returned the digit “1” for the first consonant after the initial letter, with no clear separation of responsibilities.

After:

	•	Refactored the EncodedDigits method to call a new helper method EncodedDigit for returning the digit “1”.
	•	This change modularizes the logic, making it easier to extend or modify the encoding of individual digits in the future.