### PR TITLE
Add test for consonant-to-digit mapping and implement necessary encoding logic

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -10,13 +10,14 @@ public class Soundex
 
     private string EncodedDigits(string word)
     {
-        return word.Length > 1 ? EncodedDigit() : string.Empty;
+        return word.Length > 1 ? EncodedDigit(word[1]) : string.Empty;
     }
 
-    private string EncodedDigit()
+    private string EncodedDigit(char letter)
     {
-        return "1";
+        return letter == 'c' ? "2" : "1";
     }
+    
     private string Head(string word)
     {
         var encoded = word.Substring(0, 1);

--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -20,5 +20,6 @@ public class SoundexEncodingTest
     public void ReplacesConsonantsWithAppropriateDigits()
     {
         Assert.Equal("A100", _soundex.Encode("Ab"));
+        Assert.Equal("A200", _soundex.Encode("Ac"));
     }
 }


### PR DESCRIPTION


Before:

	•	The test suite only verified the consonant “b” being encoded as “1”.
	•	The EncodedDigits method returned a hardcoded “1” without distinguishing between different consonants.

After:

	•	Added tests to ensure the Encode method correctly maps consonants “b” to “1” and “c” to “2”.
	•	Updated the EncodedDigits method to call EncodedDigit with the specific consonant, implementing the logic to return “1” for “b” and “2” for “c”.
	•	Adjusted the test to check that soundex.Encode("Ab") returns "A100" and soundex.Encode("Ac") returns "A200".