### PR TITLE
Add test for multiple consonant-to-digit mappings and implement dictionary-based encoding

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -15,7 +15,13 @@ public class Soundex
 
     private string EncodedDigit(char letter)
     {
-        return letter == 'c' ? "2" : "1";
+        var encoding = new Dictionary<char, string>
+        {
+            {'b', "1"},
+            {'c', "2"},
+            {'d', "3"}
+        };
+        return encoding.TryGetValue(letter, out var digit) ? digit : string.Empty;
     }
     
     private string Head(string word)

--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -21,5 +21,6 @@ public class SoundexEncodingTest
     {
         Assert.Equal("A100", _soundex.Encode("Ab"));
         Assert.Equal("A200", _soundex.Encode("Ac"));
+        Assert.Equal("A300", _soundex.Encode("Ad"));
     }
 }


### PR DESCRIPTION
Before:

	•	The test only covered the encoding of consonants “b” and “c”, and the EncodedDigit method handled these with simple conditional logic.
	•	The EncodedDigit method did not support additional consonants like “d”.

After:

	•	Added a test case to check the encoding of the consonant “d”, ensuring that soundex.Encode("Ad") returns "A300".
	•	Refactored the EncodedDigit method to use a dictionary for mapping consonants to their corresponding digits, supporting “b”, “c”, and “d”.
	•	This dictionary-based approach simplifies the addition of new consonant mappings and ensures consistent encoding logic.