### PR TITLE
Add test and expand consonant-to-digit mappings in EncodedDigit method

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -16,10 +16,14 @@ public class Soundex
     private string EncodedDigit(char letter)
     {
         var encoding = new Dictionary<char, string>
-        {
-            {'b', "1"},
-            {'c', "2"},
-            {'d', "3"}
+        { 
+            {'b', "1"}, {'f', "1"}, {'p', "1"}, {'v', "1"},
+            {'c', "2"}, {'g', "2"}, {'j', "2"}, {'k', "2"}, {'q', "2"},
+            {'s', "2"}, {'x', "2"}, {'z', "2"},
+            {'d', "3"}, {'t', "3"},
+            {'l', "4"},
+            {'m', "5"}, {'n', "5"},
+            {'r', "6"}
         };
         return encoding.TryGetValue(letter, out var digit) ? digit : string.Empty;
     }

--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -22,5 +22,6 @@ public class SoundexEncodingTest
         Assert.Equal("A100", _soundex.Encode("Ab"));
         Assert.Equal("A200", _soundex.Encode("Ac"));
         Assert.Equal("A300", _soundex.Encode("Ad"));
+        Assert.Equal("A200", _soundex.Encode("Ax"));
     }
 }


### PR DESCRIPTION
Before:

	•	The EncodedDigit method handled a limited set of consonants, using simple conditional logic or a small dictionary to map them to digits.
	•	The test suite did not cover consonants like “x”, which are encoded as “2” according to the Soundex rules.

After:

	•	Added a test to ensure that the consonant “x” is correctly encoded as “2”, with the expectation that soundex.Encode("Ax") returns "A200".
	•	Expanded the EncodedDigit method to use a more comprehensive dictionary that includes mappings for all consonants to their respective digits.
	•	This update ensures that the Soundex encoding method correctly handles a wider range of consonants, improving the accuracy and completeness of the encoding logic.