### PR TITLE
Add test to ensure Encode method ignores non-alphabetic characters and implement logic

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -25,7 +25,7 @@ public class Soundex
             {'m', "5"}, {'n', "5"},
             {'r', "6"}
         };
-        return encoding[letter];
+        return encoding.TryGetValue(letter, out var digit) ? digit : string.Empty;
     }
     
     private string Head(string word)

--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -24,4 +24,10 @@ public class SoundexEncodingTest
         Assert.Equal("A300", _soundex.Encode("Ad"));
         Assert.Equal("A200", _soundex.Encode("Ax"));
     }
+    
+    [Fact]
+    public void IgnoresNonAlphabetics()
+    {
+        Assert.Equal("A000", _soundex.Encode("A#"));
+    }
 }


### PR DESCRIPTION

Before:

	•	The EncodedDigit method mapped consonants to their respective digits but did not handle non-alphabetic characters.
	•	There was no test to verify that non-alphabetic characters, such as #, are ignored during the encoding process.

After:

	•	Added a test to verify that the Encode method ignores non-alphabetic characters. The test checks that soundex.Encode("A#") returns "A000", ensuring that the # is not encoded.
	•	Updated the EncodedDigit method to safely return an empty string ("") if the character is not found in the encodings map, effectively ignoring non-alphabetic characters.