### PR TITLE
Add test for encoding multiple consonants to digits in Encode method

### DIFF
--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -30,4 +30,10 @@ public class SoundexEncodingTest
     {
         Assert.Equal("A000", _soundex.Encode("A#"));
     }
+    
+    [Fact]
+    public void ReplacesMultipleConsonantsWithDigits()
+    {
+        Assert.Equal("A234", _soundex.Encode("Acdl"));
+    }
 }


### PR DESCRIPTION
Before:

	•	The Soundex test suite only verified the encoding of single consonants following the initial letter but did not test for sequences of multiple consonants.
	•	There was no validation to ensure that a sequence of consonants like “cdl” was correctly encoded as “234”.

After:

	•	Added a test to verify that the Encode method correctly encodes the sequence of consonants in the input “Acdl” to produce "A234".
	•	This test ensures that the Soundex encoding logic correctly handles multiple consonants, encoding each according to the Soundex rules.