### PR TITLE
Remove redundant empty check in EncodedDigits method

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -11,8 +11,6 @@ public class Soundex
     private string EncodedDigits(string word)
     {
         var encoding = string.Empty;
-        if (string.IsNullOrEmpty(word))
-            return string.Empty;
         foreach (var letter in word)
         {
             encoding += EncodedDigit(letter);


### PR DESCRIPTION
Before:

	•	The EncodedDigits method included a check for an empty string at the beginning, returning an empty string if the input was empty.
	•	This check was redundant because the method now iterates over each character in the word, naturally handling empty input without needing explicit checks.

After:

	•	Removed the redundant if (string.IsNullOrEmpty(word)) return string.Empty; check from the EncodedDigits method.
	•	The method now directly iterates over the characters in the word, constructing the encoding string without the need for an early exit condition.
	•	This change simplifies the code by removing unnecessary checks, relying on the iteration logic to handle all cases, including empty input.