### PR TITLE
Limit the length of encoded digits to maintain Soundex code length

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -13,6 +13,8 @@ public class Soundex
         var encoding = string.Empty;
         foreach (var letter in word)
         {
+            if (encoding.Length == MaxCodeLength - 1)
+                break;
             encoding += EncodedDigit(letter);
         }
 


### PR DESCRIPTION
Before:

	•	The EncodedDigits method continued encoding characters from the word’s tail without considering the maximum length of the resulting Soundex code.
	•	This could result in an encoded string longer than the allowed Soundex length of four characters.

After:

	•	Updated the EncodedDigits method to stop encoding additional characters once the length of the encoding string reaches MaxCodeLength - 1.
	•	This ensures that the encoded string does not exceed the allowed length, maintaining compliance with the Soundex standard.
	•	The method now correctly handles the length restriction, breaking the loop when the maximum length is approached.