### PR TITLE
Refactor EncodedDigits method to use IsComplete helper for length check

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -13,14 +13,17 @@ public class Soundex
         var encoding = string.Empty;
         foreach (var letter in word)
         {
-            if (encoding.Length == MaxCodeLength - 1)
+            if (IsComplete(encoding))
                 break;
             encoding += EncodedDigit(letter);
         }
 
         return encoding;
     }
-
+    private bool IsComplete(string encoding)
+    {
+        return encoding.Length == MaxCodeLength - 1;
+    }
     private string EncodedDigit(char letter)
     {
         var encoding = new Dictionary<char, string>


### PR DESCRIPTION
Before:

	•	The EncodedDigits method directly checked if the length of the encoding string reached MaxCodeLength - 1 to determine when to stop encoding additional characters.
	•	This logic was embedded in the loop, making the code less modular and slightly harder to maintain.

After:

	•	Refactored the EncodedDigits method to use a new helper method IsComplete, which encapsulates the logic for determining if the encoding is complete.
	•	The IsComplete method checks if the encoding length has reached MaxCodeLength - 1, making the main encoding loop cleaner and more readable.
	•	This change improves code modularity by isolating the length-checking logic into a dedicated method, enhancing maintainability and clarity.