### PR TITLE
Add test to ensure Encode method ignores vowel-like letters

### DIFF
--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -41,4 +41,9 @@ public class SoundexEncodingTest
     {
         Assert.Equal(4, _soundex.Encode("Dcdlb").Length);
     }
+    [Fact]
+    public void IgnoresVowelLikeLetters()
+    {
+        Assert.Equal("B234", _soundex.Encode("Baeiouhycdl"));
+    }
 }


### PR DESCRIPTION
Before:

	•	The Soundex method handled consonant encoding but did not have a test to ensure that vowel-like letters (a, e, i, o, u, h, y) were ignored during encoding.
	•	Without this test, there was a risk that vowel-like letters might be incorrectly included in the encoded string.

After:

	•	Added a test to verify that the Encode method ignores vowel-like letters and focuses only on consonants for encoding.
	•	The test checks that soundex.Encode("Baeiouhycdl") returns "B234", confirming that all vowel-like letters are correctly ignored during the encoding process.
	•	This test ensures that the Soundex encoding logic adheres to the Soundex rule of ignoring vowel-like letters.