### PR TITLE
Add test to ensure Encode method combines duplicate encodings

### DIFF
--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -46,4 +46,9 @@ public class SoundexEncodingTest
     {
         Assert.Equal("B234", _soundex.Encode("Baeiouhycdl"));
     }
+    [Fact]
+    public void CombinesDuplicateEncodings()
+    {
+        Assert.Equal("A123", _soundex.Encode("Abfcgdt"));
+    }
 }


### PR DESCRIPTION
Before:

	•	The Soundex encoding logic handled individual consonant encodings but did not account for the possibility of duplicate encodings (e.g., different consonants that map to the same digit).
	•	There was no test to ensure that when multiple consonants map to the same digit consecutively, only one digit is included in the final encoding.

After:

	•	Added a test to verify that the Encode method correctly combines duplicate encodings when consonants that map to the same digit appear consecutively.
	•	The test checks that soundex.Encode("Abfcgdt") returns "A123", confirming that consecutive consonants that map to the same digit are combined into a single digit in the encoded string.
	•	This test ensures that the Soundex encoding method adheres to the Soundex rule of combining duplicate encodings.