### PR TITLE
Add tests to verify combining duplicate encodings and equality of encoding digits

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -24,7 +24,7 @@ public class Soundex
     {
         return encoding.Length == MaxCodeLength - 1;
     }
-    private string EncodedDigit(char letter)
+    public string EncodedDigit(char letter)
     {
         var encoding = new Dictionary<char, string>
         { 

--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -49,6 +49,8 @@ public class SoundexEncodingTest
     [Fact]
     public void CombinesDuplicateEncodings()
     {
-        Assert.Equal("A123", _soundex.Encode("Abfcgdt"));
-    }
+        Assert.Equal(_soundex.EncodedDigit('b'), _soundex.EncodedDigit('f'));
+        Assert.Equal(_soundex.EncodedDigit('c'), _soundex.EncodedDigit('g'));
+        Assert.Equal(_soundex.EncodedDigit('d'), _soundex.EncodedDigit('t'));
+        Assert.Equal("A123", _soundex.Encode("Abfcgdt"));    }
 }


### PR DESCRIPTION

Before:

	•	The Soundex method handled basic encoding but lacked tests to ensure that specific consonants mapping to the same digit were treated equally.
	•	There was no verification that the encoding for b was the same as for f, c the same as for g, and d the same as for t.
	•	The previous test only confirmed the final encoded string without checking the equivalence of individual digit mappings.

After:

	•	Added tests to verify that soundex.EncodedDigit('b') equals soundex.EncodedDigit('f'), soundex.EncodedDigit('c') equals soundex.EncodedDigit('g'), and soundex.EncodedDigit('d') equals soundex.EncodedDigit('t').
	•	This confirms that consonants with the same Soundex digit are treated equivalently in the encoding logic.
	•	Also, confirmed that soundex.Encode("Abfcgdt") returns "A123", ensuring that the final encoded string correctly combines these equivalent encodings into a single digit per group.