### PR TITLE
Enhance EncodedDigits method to combine duplicate encodings using LastDigit check

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -15,10 +15,17 @@ public class Soundex
         {
             if (IsComplete(encoding))
                 break;
-            encoding += EncodedDigit(letter);
+
+            if (EncodedDigit(letter) != LastDigit(encoding))
+                encoding += EncodedDigit(letter);
         }
 
         return encoding;
+    }
+
+    private string LastDigit(string encoding)
+    {
+        return string.IsNullOrEmpty(encoding) ? string.Empty : encoding[^1].ToString();
     }
     private bool IsComplete(string encoding)
     {


### PR DESCRIPTION

Before:

	•	The EncodedDigits method combined duplicate consonant encodings but lacked a mechanism to prevent consecutive duplicate digits from being added to the final encoding.
	•	There was no utility to check the last digit of the current encoding, leading to potential inclusion of consecutive duplicate digits.

After:

	•	Introduced a LastDigit method to retrieve the last digit of the current encoding, allowing the EncodedDigits method to check for consecutive duplicates.
	•	Updated the EncodedDigits method to only add a new digit if it is different from the last digit in the encoding, preventing consecutive duplicates.
	•	This enhancement ensures that the final encoded string adheres to Soundex rules by combining and avoiding consecutive duplicate digits.