### PR TITLE
Add test and implement logic to uppercase the first letter in Encode method

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -5,9 +5,12 @@ public class Soundex
     private const int MaxCodeLength = 4;
     public string Encode(string word)
     {
-        return ZeroPad(Head(word) + EncodedDigits(Tail(word)));
+        return ZeroPad(UpperFront(Head(word)) + EncodedDigits(Tail(word)));
     }
-
+    private string UpperFront(string input)
+    {
+        return input.Length > 0 ? char.ToUpper(input[0]).ToString() : string.Empty;
+    }
     private string EncodedDigits(string word)
     {
         var encoding = string.Empty;

--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -52,5 +52,12 @@ public class SoundexEncodingTest
         Assert.Equal(_soundex.EncodedDigit('b'), _soundex.EncodedDigit('f'));
         Assert.Equal(_soundex.EncodedDigit('c'), _soundex.EncodedDigit('g'));
         Assert.Equal(_soundex.EncodedDigit('d'), _soundex.EncodedDigit('t'));
-        Assert.Equal("A123", _soundex.Encode("Abfcgdt"));    }
+        Assert.Equal("A123", _soundex.Encode("Abfcgdt"));    
+    }
+    
+    [Fact]
+    public void UppercasesFirstLetter()
+    {
+        Assert.StartsWith("A", _soundex.Encode("abcd"));
+    }
 }


### PR DESCRIPTION
Before:

	•	The Soundex encoding method processed the input string but did not ensure that the first letter of the encoded output was uppercase.
	•	The test suite lacked a verification to ensure the first letter of the encoded string was capitalized, as required by Soundex rules.

After:

	•	Added a test to verify that the Encode method capitalizes the first letter of the input string, ensuring that the encoded output starts with this uppercase letter.
	•	Introduced the UpperFront method, which converts the first character of the input string to uppercase.
	•	Updated the Encode method to use UpperFront for processing the first character, ensuring the encoded string starts with an uppercase letter.
	•	This change ensures compliance with the Soundex rule that the first letter of the encoded output is capitalized, and the test suite now verifies this behavior.