### PR TITLE
Add test to ensure Encode method ignores all vowel-like letters

### DIFF
--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -44,7 +44,7 @@ public class SoundexEncodingTest
     [Fact]
     public void IgnoresVowelLikeLetters()
     {
-        Assert.Equal("B234", _soundex.Encode("Baeiouhycdl"));
+        Assert.Equal("B234", _soundex.Encode("BaAeEiIoOuUhHyYcdl"));
     }
     [Fact]
     public void CombinesDuplicateEncodings()


### PR DESCRIPTION
Before:

	•	The Soundex encoding method handled consonant encoding but required a test to verify that all vowel-like letters (a, e, i, o, u, h, y, in both uppercase and lowercase) were ignored during encoding.
	•	Without this test, there was a risk that vowel-like letters might incorrectly be included in the encoded string.

After:

	•	Added a test to verify that the Encode method ignores all vowel-like letters, regardless of their case.
	•	The test checks that soundex.Encode("BaAeEiIoOuUhHyYcdl") returns "B234", confirming that all vowel-like letters are ignored during the encoding process.
	•	This test ensures that the Soundex encoding logic correctly follows the rule of ignoring vowel-like letters, both uppercase and lowercase, ensuring the integrity of the encoded output.