### PR TITLE
Introduce NotADigit constant and update methods to handle non-digit characters

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -3,6 +3,7 @@
 public class Soundex
 {
     private const int MaxCodeLength = 4;
+    public const string NotADigit = "*";
     public string Encode(string word)
     {
         return ZeroPad(UpperFront(Head(word)) + EncodedDigits(Tail(word)));
@@ -18,8 +19,9 @@ public class Soundex
         {
             if (IsComplete(encoding))
                 break;
-
-            if (EncodedDigit(letter) != LastDigit(encoding))
+            
+            var digit = EncodedDigit(letter);
+            if (digit != NotADigit && digit != LastDigit(encoding))
                 encoding += EncodedDigit(letter);
         }
 
@@ -28,7 +30,7 @@ public class Soundex
 
     private string LastDigit(string encoding)
     {
-        return string.IsNullOrEmpty(encoding) ? string.Empty : encoding[^1].ToString();
+        return string.IsNullOrEmpty(encoding) ? NotADigit : encoding[^1].ToString();
     }
     private bool IsComplete(string encoding)
     {
@@ -46,7 +48,7 @@ public class Soundex
             {'m', "5"}, {'n', "5"},
             {'r', "6"}
         };
-        return encoding.TryGetValue(letter, out var digit) ? digit : string.Empty;
+        return encoding.TryGetValue(letter, out var digit) ? digit : NotADigit;
     }
     
     private string Head(string word)


### PR DESCRIPTION
…haracters

Before:

	•	The EncodedDigits method did not have a clear way to handle cases where a letter does not map to a digit, potentially leading to errors in the encoding process.
	•	The LastDigit method returned an empty string when there was no previous digit, which could lead to unclear logic when checking for duplicates.
	•	The EncodedDigit method returned an empty string if the character wasn’t found in the encodings dictionary, leading to similar issues.

After:

	•	Introduced the NotADigit constant to represent cases where a character does not correspond to a Soundex digit.
	•	Updated the EncodedDigits method to check if the current digit is NotADigit before adding it to the encoding, ensuring only valid digits are included.
	•	Updated the LastDigit method to return NotADigit instead of an empty string when there is no last digit, clarifying the logic for checking duplicates.
	•	Modified the EncodedDigit method to return NotADigit for characters not found in the encodings dictionary, improving the robustness of the encoding process.