### PR TITLE
Add test and implement case-insensitive consonant encoding

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -48,7 +48,8 @@ public class Soundex
             {'m', "5"}, {'n', "5"},
             {'r', "6"}
         };
-        return encoding.TryGetValue(letter, out var digit) ? digit : NotADigit;
+        var lowerCaseLetter = Lower(letter);
+        return encoding.TryGetValue(lowerCaseLetter, out var digit) ? digit : NotADigit;
     }
     
     private string Head(string word)
@@ -59,6 +60,10 @@ public class Soundex
     private string Tail(string word)
     {
         return word.Substring(1);
+    }
+    private char Lower(char c)
+    {
+        return char.ToLower(c);
     }
     private string ZeroPad(string word)
     {

--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -60,4 +60,10 @@ public class SoundexEncodingTest
     {
         Assert.StartsWith("A", _soundex.Encode("abcd"));
     }
+    
+    [Fact]
+    public void IgnoresCaseWhenEncodingConsonants()
+    {
+        Assert.Equal(_soundex.Encode("BCDL"), _soundex.Encode("Bcdl"));
+    }   
 }


### PR DESCRIPTION
Before:

	•	The Soundex method processed consonants but did not handle case insensitivity, potentially leading to different encodings for uppercase and lowercase versions of the same consonant.
	•	There was no test to ensure that consonants were encoded the same way regardless of their case.

After:

	•	Added a test to verify that the Encode method treats uppercase and lowercase consonants identically, ensuring case insensitivity.
	•	Introduced a Lower method to convert characters to lowercase before encoding, ensuring consistent handling of consonants regardless of case.
	•	Updated the EncodedDigit method to use the Lower method when looking up consonant mappings, ensuring that "Bcdl" and "BCDL" produce the same encoded string.
	•	This change ensures that the Soundex encoding method adheres to the rule of case insensitivity, treating uppercase and lowercase consonants equivalently.