### PR TITLE
Add test and update Encode method to combine duplicate codes when the 2nd letter duplicates the 1st

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -6,7 +6,7 @@ public class Soundex
     public const string NotADigit = "*";
     public string Encode(string word)
     {
-        return ZeroPad(UpperFront(Head(word)) + EncodedDigits(Tail(word)));
+        return ZeroPad(UpperFront(Head(word)) + Tail(EncodedDigits(word)));
     }
     private string UpperFront(string input)
     {
@@ -14,8 +14,9 @@ public class Soundex
     }
     private string EncodedDigits(string word)
     {
-        var encoding = string.Empty;
-        foreach (var letter in word)
+        var encoding = string.Empty; 
+        encoding += EncodedDigit(word[0]);
+        foreach (var letter in Tail(word))
         {
             if (IsComplete(encoding))
                 break;
@@ -34,7 +35,7 @@ public class Soundex
     }
     private bool IsComplete(string encoding)
     {
-        return encoding.Length == MaxCodeLength - 1;
+        return encoding.Length == MaxCodeLength;
     }
     public string EncodedDigit(char letter)
     {

--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -65,5 +65,11 @@ public class SoundexEncodingTest
     public void IgnoresCaseWhenEncodingConsonants()
     {
         Assert.Equal(_soundex.Encode("BCDL"), _soundex.Encode("Bcdl"));
-    }   
+    }
+    
+    [Fact]
+    public void CombinesDuplicateCodesWhenSecondLetterDuplicatesFirst()
+    {
+        Assert.Equal("B230", _soundex.Encode("Bbcd"));
+    }
 }


### PR DESCRIPTION

Before:

	•	The Soundex encoding logic handled basic encoding but did not correctly combine duplicate codes when the second letter duplicated the first, leading to potential errors in the encoded output.
	•	There was no test to ensure that the encoding logic combined such duplicates correctly, particularly when the first two letters of the word resulted in the same Soundex digit.

After:

	•	Added a test to verify that the Encode method combines duplicate codes when the second letter duplicates the first. The test ensures that soundex.Encode("Bbcd") returns "B230", combining the duplicate b encodings.
	•	Updated the EncodedDigits method to start by encoding the first letter and then process the tail of the word, ensuring that duplicate codes are correctly combined.
	•	Adjusted the IsComplete method to account for the maximum allowed length of the Soundex code, ensuring that no more than four characters are included in the final encoded output.