### PR TITLE
Refactor EncodedDigits method to adhere to the Single Responsibility Principle (SRP)

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -14,8 +14,14 @@ public class Soundex
     }
     private string EncodedDigits(string word)
     {
-        var encoding = string.Empty; 
-        encoding += EncodedDigit(word[0]);
+        var encoding = string.Empty;
+        EncodHead( ref encoding, word);
+        EncodingTail(ref encoding,word);
+        return encoding;
+    }
+
+    private void EncodingTail(ref string encoding, string word)
+    {
         foreach (var letter in Tail(word))
         {
             if (IsComplete(encoding))
@@ -25,8 +31,11 @@ public class Soundex
             if (digit != NotADigit && digit != LastDigit(encoding))
                 encoding += EncodedDigit(letter);
         }
+    }
 
-        return encoding;
+    private void EncodHead(ref string encoding, string word)
+    {
+        encoding += EncodedDigit(word[0]);
     }
 
     private string LastDigit(string encoding)


### PR DESCRIPTION

Before:

	•	The EncodedDigits method was responsible for both the high-level policy of encoding the word and the low-level implementation details, violating the Single Responsibility Principle (SRP).
	•	This made the method complex, difficult to maintain, and prone to change for multiple reasons.

After:

	•	Refactored the EncodedDigits method by extracting the logic into two separate methods: EncodeHead and EncodeTail.
	•	EncodeHead is responsible for encoding the first letter of the word.
	•	EncodeTail handles the encoding of the remaining characters in the word.
	•	This separation allows each method to focus on a single responsibility, making the code more modular, easier to maintain, and aligned with SRP.
	•	The EncodedDigits method now serves as a high-level orchestrator that delegates the specific encoding tasks to these new methods.