### PR TITLE
Enhance encoding logic to avoid combining duplicate codes separated by vowels

### DIFF
--- a/TDD-CSharp.Sources/Soundex.cs
+++ b/TDD-CSharp.Sources/Soundex.cs
@@ -22,18 +22,25 @@ public class Soundex
 
     private void EncodingTail(ref string encoding, string word)
     {
-        foreach (var letter in Tail(word))
+        for (var i = 1; i < word.Length; i++)
         {
-            if (!IsComplete(encoding)) 
-                EncodeLetter(ref encoding, letter);
+            if (!IsComplete(encoding))
+                EncodeLetter(ref encoding, word[i], word[i - 1]);
         }
     }
     
-    private void EncodeLetter(ref string encoding, char letter)
+    private void EncodeLetter(ref string encoding, char letter, char lastLetter)
     {
         var digit = EncodedDigit(letter);
-        if (digit != NotADigit && digit != LastDigit(encoding))
+        if (digit != NotADigit && 
+            (digit != LastDigit(encoding) || IsVowel(lastLetter)))
+        {
             encoding += digit;
+        }
+    }
+    private bool IsVowel(char letter)
+    {
+        return "aeiouy".Contains(Lower(letter));
     }
 
     private void EncodHead(ref string encoding, string word)

--- a/TDD-CSharp.Tests/SoundexEncodingTest.cs
+++ b/TDD-CSharp.Tests/SoundexEncodingTest.cs
@@ -72,4 +72,10 @@ public class SoundexEncodingTest
     {
         Assert.Equal("B230", _soundex.Encode("Bbcd"));
     }
+    
+    [Fact]
+    public void DoesNotCombineDuplicateEncodingsSeparatedByVowels()
+    {
+        Assert.Equal("J110", _soundex.Encode("Jbob"));
+    }
 }


### PR DESCRIPTION

Before:

	•	The EncodeTail method handled the encoding of letters but did not properly account for situations where duplicate consonant encodings were separated by vowels.
	•	This could lead to incorrect combinations of consonant encodings, violating the Soundex rules.

After:

	•	Added a test to verify that the Encode method does not combine duplicate encodings that are separated by vowels. The test ensures that soundex.Encode("Jbob") returns "J110", confirming that the b characters are encoded separately, despite the vowel o in between.
	•	Refactored the EncodeTail method to iterate through the word starting from the second character, checking if the encoding is complete before encoding each letter.
	•	Introduced a new EncodeLetter method that handles the encoding of each letter, ensuring that duplicate encodings are not combined if they are separated by a vowel.
	•	Added an IsVowel method to determine if the previous letter was a vowel, allowing for proper handling of vowel-separated consonants.