### PR TITLE
Add initial tests and implementation for RetweetCollection

### DIFF
--- a/TDD-CSharp.Sources/RetweetCollection/RetweetCollection.cs
+++ b/TDD-CSharp.Sources/RetweetCollection/RetweetCollection.cs
@@ -1,0 +1,14 @@
+namespace TDD_CSharp.Sources.RetweetCollection;
+
+public class RetweetCollection
+{
+    public bool IsEmpty()
+    {
+        return Size() == 0;
+    }
+
+    public uint Size()
+    {
+        return 0;
+    }
+}

--- a/TDD-CSharp.Sources/TDD-CSharp.Sources.csproj
+++ b/TDD-CSharp.Sources/TDD-CSharp.Sources.csproj
@@ -8,8 +8,4 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
-    <ItemGroup>
-      <Folder Include="RetweetCollection\" />
-    </ItemGroup>
-
 </Project>

--- a/TDD-CSharp.Tests/RetweetCollectionTests.cs
+++ b/TDD-CSharp.Tests/RetweetCollectionTests.cs
@@ -1,10 +1,20 @@
+using TDD_CSharp.Sources.RetweetCollection;
+
 namespace TDD_CSharp.Tests;
 
 public class RetweetCollectionTests
 {
+    private readonly RetweetCollection _collection = new RetweetCollection();
+
     [Fact]
     public void IsEmptyWhenCreated()
     {
-        var retweets = new RetweetCollection();
+        Assert.True(_collection.IsEmpty());
+    }
+
+    [Fact]
+    public void HasSizeZeroWhenCreated()
+    {
+        Assert.Equal(0u, _collection.Size());
     }
 }


### PR DESCRIPTION
Before:

	•	The RetweetCollection class did not have any tests or basic implementation for checking if it is empty or its size.

After:

	•	Added basic implementation for RetweetCollection with methods IsEmpty and Size, both returning values that ensure the collection is empty when created.
	•	Added tests IsEmptyWhenCreated and HasSizeZeroWhenCreated to validate that a newly created RetweetCollection is empty and has a size of zero.