### PR TITLE
Add test to verify RetweetCollection size is one after adding a tweet

### DIFF
--- a/TDD-CSharp.Sources/RetweetCollection/Tweet.cs
+++ b/TDD-CSharp.Sources/RetweetCollection/Tweet.cs
@@ -1,0 +1,6 @@
+namespace TDD_CSharp.Sources.RetweetCollection;
+
+public class Tweet
+{
+    
+}

--- a/TDD-CSharp.Tests/RetweetCollectionTests.cs
+++ b/TDD-CSharp.Tests/RetweetCollectionTests.cs
@@ -24,4 +24,11 @@ public class RetweetCollectionTests
         _collection.Add(new Tweet());
         Assert.False(_collection.IsEmpty());
     }
+    
+    [Fact]
+    public void HasSizeOfOneAfterTweetAdded()
+    {
+        _collection.Add(new Tweet());
+        Assert.Equal(1u, _collection.Size());
+    }
 }


### PR DESCRIPTION
Before:

	•	The RetweetCollection class allowed adding a tweet, but there was no test to verify that the collection size correctly updates after adding a tweet.

After:

	•	Added the test HasSizeOfOneAfterTweetAdded to verify that the RetweetCollection size is updated to 1 after adding a single tweet.
	•	This test ensures that the internal size tracking of the collection is functioning correctly when a tweet is added.
