### PR TITLE
Update Size method to return 0 when empty and 1 when not

### DIFF
--- a/TDD-CSharp.Sources/RetweetCollection/RetweetCollection.cs
+++ b/TDD-CSharp.Sources/RetweetCollection/RetweetCollection.cs
@@ -21,6 +21,6 @@ public class RetweetCollection
 
     public uint Size()
     {
-        return 0;
+        return IsEmpty() ? 0u : 1u;
     }  
 }


### PR DESCRIPTION
Before:

	•	The Size method in the RetweetCollection class returned 0 regardless of whether a tweet had been added or not, which did not reflect the state of the collection accurately.

After:

	•	Updated the Size method to return 0 if the collection is empty and 1 if a tweet has been added.
	•	This change ensures that the Size method accurately reflects the state of the collection, returning the appropriate size based on whether the collection is empty or not.