### PR TITLE
Add test to verify size decreases after removing a tweet from RetweetCollection

### DIFF
--- a/TDD-CSharp.Tests/RetweetCollectionTests.cs
+++ b/TDD-CSharp.Tests/RetweetCollectionTests.cs
@@ -31,4 +31,15 @@ public class RetweetCollectionTests
         _collection.Add(new Tweet());
         Assert.Equal(1u, _collection.Size());
     }
+    
+    [Fact]
+    public void DecreasesSizeAfterRemovingTweet()
+    {
+        var tweet = new Tweet();
+        _collection.Add(tweet);
+        _collection.Remove(tweet);
+        
+        Assert.Equal(0u, _collection.Size());
+        Assert.True(_collection.IsEmpty()); // DON'T DO THIS
+    }
 }


### PR DESCRIPTION
Before:

	•	The RetweetCollection class allowed adding tweets but lacked the functionality to remove a tweet and verify that the size decreases appropriately.

After:

	•	Added a test DecreasesSizeAfterRemovingTweet to verify that the size of the RetweetCollection decreases to 0 after a tweet is removed.