### PR TITLE
Add custom assertion to validate size and empty state together in RetweetCollection

### DIFF
--- a/TDD-CSharp.Tests/RetweetCollectionTests.cs
+++ b/TDD-CSharp.Tests/RetweetCollectionTests.cs
@@ -32,32 +32,23 @@ public class RetweetCollectionTests
         Assert.Equal(1u, _collection.Size());
     }
     
+    private void AssertHasSize(RetweetCollection collection, uint expectedSize)
+    {
+        Assert.Equal(expectedSize, collection.Size());
+        Assert.Equal(expectedSize == 0, collection.IsEmpty());
+    }
+
     [Fact]
     public void DecreasesSizeAfterRemovingTweet()
     {
-        //Arrange
+        // Arrange
         var tweet = new Tweet();
-        
-        //Act
         _collection.Add(tweet);
-        _collection.Remove(tweet);
-        
-        //Assert
-        Assert.Equal(0u, _collection.Size());
-    }
 
-    // AVOID doing this
-    [Fact]
-    public void IsEmptyAfterRemovingTweet()
-    {
-        //Arrange
-        var tweet = new Tweet();
-        
-        //Act
-        _collection.Add(tweet);
+        // Act
         _collection.Remove(tweet);
-        
-        //Assert
-        Assert.True(_collection.IsEmpty());
+
+        // Assert
+        AssertHasSize(_collection, 0u);
     }
 }


### PR DESCRIPTION
Before:

	•	The tests for RetweetCollection separately asserted the size and empty state, which are conceptually linked, leading to redundancy and potential inconsistencies.

After:

	•	Introduced a custom assertion method AssertHasSize that checks both the size and the empty state of the RetweetCollection in a single assertion.
	•	Refactored the DecreasesSizeAfterRemovingTweet test to use the custom assertion, improving clarity and reducing redundancy.