### PR TITLE
Add test to verify that RetweetCollection ignores duplicate tweets

### DIFF
--- a/TDD-CSharp.Tests/RetweetCollectionTests.cs
+++ b/TDD-CSharp.Tests/RetweetCollectionTests.cs
@@ -55,4 +55,20 @@ public class RetweetCollectionTests
         Assert.True(size > 0u);
         Assert.False(isEmpty);
     }
+    
+    [Fact]
+    public void IgnoresDuplicateTweetAdded()
+    {
+        // Arrange
+        var tweet = new Tweet("msg", "@user");
+        var duplicate = new Tweet(tweet);
+
+        // Act
+        _collection.Add(tweet);
+        _collection.Add(duplicate);
+        var size = _collection.Size();
+
+        // Assert
+        Assert.Equal(1u, size);
+    }
 }


### PR DESCRIPTION
Before:

	•	The RetweetCollection class allowed adding tweets but did not explicitly handle or test the case where a duplicate tweet was added.

After:

	•	Added the IgnoresDuplicateTweetAdded test to verify that the RetweetCollection ignores a duplicate tweet, ensuring that the size of the collection remains 1.
	•	This test ensures that the RetweetCollection correctly handles duplicate tweets, maintaining an accurate count of unique tweets.