### PR TITLE
Add specific tweet in setup for tests in RetweetCollectionWithOneTweetTests

### DIFF
--- a/TDD-CSharp.Tests/RetweetCollectionTests.cs
+++ b/TDD-CSharp.Tests/RetweetCollectionTests.cs
@@ -80,10 +80,9 @@ public class RetweetCollectionTests
         // Act
         _collection.Add(tweet);
         _collection.Add(duplicate);
-        var size = _collection.Size();
 
         // Assert
-        Assert.Equal(1u, size);
+        Assert.Equal(1u, _collection.Size());
     }
 }
 
@@ -95,7 +94,7 @@ public class RetweetCollectionWithOneTweetTests
     public RetweetCollectionWithOneTweetTests()
     {
         _collection = new RetweetCollection();
-        _collection.Add(new Tweet());
+        _collection.Add(new Tweet("msg", "@user"));
     }
 
     [Fact]


### PR DESCRIPTION

Before:

	•	The setup for the RetweetCollectionWithOneTweet test class did not involve adding a tweet with specific content, potentially limiting the scope of the tests.

After:

	•	Refactored the setup in the RetweetCollectionWithOneTweetTests class to add a tweet with specific content (“msg”, “@user”) to the RetweetCollection.
	•	This setup ensures that all tests within the class operate on a collection containing a tweet with known content, making the tests more robust and meaningful.