### PR TITLE
Add test to verify ArgumentException is thrown with correct message for invalid username

### DIFF
--- a/TDD-CSharp.Tests/TweetTests.cs
+++ b/TDD-CSharp.Tests/TweetTests.cs
@@ -1,3 +1,5 @@
+using TDD_CSharp.Sources.RetweetCollection;
+
 namespace TDD_CSharp.Tests;
 
 public class TweetTests
@@ -9,6 +11,9 @@ public class TweetTests
         var invalidUser = "notStartingWith@";
 
         // Act & Assert
-        Assert.Throws<ArgumentException>(() => new Tweet("msg", invalidUser));
+        var exception = Assert.Throws<ArgumentException>(() => new Tweet("msg", invalidUser));
+        
+        // Assert that the exception message matches the expected value
+        Assert.Equal("Invalid user: User must start with '@'.", exception.Message);
     }
 }


### PR DESCRIPTION
Before:

	•	There was no test to verify that an exception is thrown with the correct message when an invalid username (not starting with ‘@’) is passed to the Tweet constructor.

After:

	•	Added the RequiresUserNameToStartWithAtSign test, which verifies that an ArgumentException is thrown when the username does not start with ‘@’.
	•	The test also checks that the exception message matches the expected error message, ensuring the correctness of the validation logic.