### PR TITLE
Add URL verification in HttpStub for PlaceDescriptionService tests

### DIFF
--- a/TDD-CSharp.Sources/PlaceDescriptionService/HttpStub.cs
+++ b/TDD-CSharp.Sources/PlaceDescriptionService/HttpStub.cs
@@ -1,3 +1,5 @@
+using Xunit;
+
 namespace TDD_CSharp.Sources.PlaceDescriptionService;
 
 public class HttpStub : Http
@@ -9,11 +11,19 @@ public class HttpStub : Http
 
     public override string Get(string url)
     {
+        Verify(url);
         return @"{ ""address"": {
                     ""road"": ""Drury Ln"",
                     ""city"": ""Fountain"",
                     ""state"": ""CO"",
                     ""country"": ""US""
                  }}";
+    }
+
+    private void Verify(string url)
+    {
+        var expectedArgs = "lat=" + APlaceDescriptionService.ValidLatitude + "&" +
+                           "lon=" + APlaceDescriptionService.ValidLongitude;
+        Assert.EndsWith(expectedArgs, url);
     }
 }

--- a/TDD-CSharp.Sources/PlaceDescriptionService/PlaceDescriptionService.cs
+++ b/TDD-CSharp.Sources/PlaceDescriptionService/PlaceDescriptionService.cs
@@ -11,11 +11,10 @@ public class PlaceDescriptionService
 
     public string SummaryDescription(string latitude, string longitude)
     {
-        var getRequestUrl = ""; // URL construction can be added here
+        var getRequestUrl = "lat=" + latitude + "&lon=" + longitude;
         var jsonResponse = _http.Get(getRequestUrl);
         var extractor = new AddressExtractor();
         var address = extractor.AddressFrom(jsonResponse);
-
         return $"{address.Road}, {address.City}, {address.State}, {address.Country}";
     }
 }

--- a/TDD-CSharp.Sources/TDD-CSharp.Sources.csproj
+++ b/TDD-CSharp.Sources/TDD-CSharp.Sources.csproj
@@ -8,4 +8,8 @@
         <Nullable>enable</Nullable>
     </PropertyGroup>
 
+    <ItemGroup>
+      <PackageReference Include="xunit.assert" Version="2.4.2" />
+    </ItemGroup>
+
 </Project>


### PR DESCRIPTION
Before:

	•	The HttpStub class returned a hardcoded JSON response but did not verify the correctness of the URL used to make the request.

After:

	•	Added the Verify method in HttpStub, which checks that the URL ends with the expected latitude and longitude parameters (lat and lon).
	•	The Verify method is invoked within the Get method, ensuring that any request made through HttpStub contains the correct query parameters.